### PR TITLE
Prepare 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 - 2026-01-07
+
+### Added
+
+- Add AI watermark metadata @ marcelklehr [#40](https://github.com/nextcloud/text2speech_kokoro/pull/40)
+- Support trigger for taskprocessing @marcelklehr [#33](https://github.com/nextcloud/text2speech_kokoro/pull/33)
+
+### Fixed
+
+- Add missing packages to Dockerfile @lukasdotcom [#48](https://github.com/nextcloud/text2speech_kokoro/pull/48)
+
 ## 1.3.0 - 2025-12-01
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 APP_ID := text2speech_kokoro
 APP_NAME := Kokoro
-APP_VERSION := 1.3.0
+APP_VERSION := 1.4.0
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":9030}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Negative:
 * The training data isn't freely available, making it not possible to check or correct for bias or optimise the performance and CO2 usage.
 ]]>
     </description>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <licence>agpl</licence>
     <author mail="lukas@lschaefer.xyz" homepage="https://github.com/lukasdotcom">Lukas Schaefer</author>
     <namespace>text2speech_kokoro</namespace>
@@ -37,7 +37,7 @@ Negative:
         <docker-install>
             <registry>ghcr.io</registry>
             <image>nextcloud/text2speech_kokoro</image>
-            <image-tag>1.3.0</image-tag>
+            <image-tag>1.4.0</image-tag>
         </docker-install>
     </external-app>
 </info>


### PR DESCRIPTION
## 1.4.0 - 2026-01-07

### Added

- Add AI watermark metadata @ marcelklehr [#40](https://github.com/nextcloud/text2speech_kokoro/pull/40)
- Support trigger for taskprocessing @marcelklehr [#33](https://github.com/nextcloud/text2speech_kokoro/pull/33)

### Fixed

- Add missing packages to Dockerfile @lukasdotcom [#48](https://github.com/nextcloud/text2speech_kokoro/pull/48)