### PR TITLE
chore: Prepare 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.1 - 2026-07-27
+
+### Changed
+
+- Update workflows and dependencies and bump Nextcloud support to 35 @lukasdotcom [#69](https://github.com/nextcloud/text2speech_kokoro/pull/69)
+
 ## 1.5.0 - 2026-03-31
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 APP_ID := text2speech_kokoro
 APP_NAME := Kokoro
-APP_VERSION := 1.5.0
+APP_VERSION := 1.5.1
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":9030}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Negative:
 * The training data isn't freely available, making it not possible to check or correct for bias or optimise the performance and CO2 usage.
 ]]>
     </description>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <licence>agpl</licence>
     <author mail="lukas@lschaefer.xyz" homepage="https://github.com/lukasdotcom">Lukas Schaefer</author>
     <namespace>text2speech_kokoro</namespace>
@@ -37,7 +37,7 @@ Negative:
         <docker-install>
             <registry>ghcr.io</registry>
             <image>nextcloud/text2speech_kokoro</image>
-            <image-tag>1.5.0</image-tag>
+            <image-tag>1.5.1</image-tag>
         </docker-install>
     </external-app>
 </info>


### PR DESCRIPTION
## 1.5.1 - 2026-07-27

### Changed

- Update workflows and dependencies and bump Nextcloud support to 35 @lukasdotcom [#69](https://github.com/nextcloud/text2speech_kokoro/pull/69)